### PR TITLE
Allow custom config directory by setting FANCYWM_CONF_DIR env variable

### DIFF
--- a/FancyWM/Models/AppState.cs
+++ b/FancyWM/Models/AppState.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -10,11 +11,23 @@ namespace FancyWM.Models
 
         public AppState()
         {
-            Settings = new ObservableJsonEntity<Settings>(Path.GetFullPath("settings.json"), 
+            string SettingsDirectory;
+            string SettingsFile;
+
+#pragma warning disable CS8600
+            SettingsDirectory = Environment.GetEnvironmentVariable("FANCYWM_CONF_DIR");
+#pragma warning restore CS8600
+
+            if (SettingsDirectory == null)
+                SettingsFile = Path.GetFullPath("settings.json");
+            else
+                SettingsFile = Path.GetFullPath("settings.json", SettingsDirectory);
+
+            Settings = new ObservableJsonEntity<Settings>(SettingsFile,
                 () => new Settings
                 {
                     AutoCollapsePanels = true,
-                }, 
+                },
                 new JsonSerializerOptions
                 {
                     AllowTrailingCommas = true,


### PR DESCRIPTION
This doesn't touch the empty administrator-mode file, only settings.json for now.