### PR TITLE
Fixed MoreContextMenu not closing when focus lost

### DIFF
--- a/FancyWM/Controls/TilingWindow.xaml.cs
+++ b/FancyWM/Controls/TilingWindow.xaml.cs
@@ -44,23 +44,11 @@ namespace FancyWM.Controls
         {
             MoreContextMenu.IsOpen = true;
             MoreContextMenu.DataContext = ViewModel;
-            var child = (UIElement)VisualTreeHelper.GetChild(VisualTreeHelper.GetChild(MoreContextMenu, 0), 0);
-            child.MouseEnter -= OnContextMenuMouseEnter;
-            child.MouseEnter += OnContextMenuMouseEnter;
+            MoreContextMenu.LostFocus += OnContextMenuLostFocus;
         }
 
-        private void OnContextMenuMouseEnter(object sender, MouseEventArgs e)
+        private void OnContextMenuLostFocus(object sender, RoutedEventArgs e)
         {
-            var child = (UIElement)sender;
-            child.MouseEnter -= OnContextMenuMouseEnter;
-            child.MouseLeave -= OnContextMenuMouseLeave;
-            child.MouseLeave += OnContextMenuMouseLeave;
-        }
-
-        private void OnContextMenuMouseLeave(object sender, MouseEventArgs e)
-        {
-            var child = (UIElement)sender;
-            child.MouseLeave -= OnContextMenuMouseLeave;
             MoreContextMenu.IsOpen = false;
         }
 


### PR DESCRIPTION
Originally, opening the "More options" context menu at the top of windows will open a context menu that cannot be closed unless a FancyWM element (a panel) is clicked or an option is chosen. This fix makes it so that the context menu automatically closes when the mouse leaves it without selecting anything.