### PR TITLE
fix restore window size by using ResizeBy -> ResizeTo

### DIFF
--- a/FancyWM/TilingService.Private.cs
+++ b/FancyWM/TilingService.Private.cs
@@ -1308,11 +1308,11 @@ namespace FancyWM
                             }
                             if (splitPanel.Orientation == PanelOrientation.Horizontal)
                             {
-                                splitPanel.ResizeBy(window, savedLocation.ComputedRectangle.Width, GrowDirection.Both);
+                                splitPanel.ResizeTo(window, savedLocation.ComputedRectangle.Width, GrowDirection.Both);
                             }
                             else
                             {
-                                splitPanel.ResizeBy(window, savedLocation.ComputedRectangle.Height, GrowDirection.Both);
+                                splitPanel.ResizeTo(window, savedLocation.ComputedRectangle.Height, GrowDirection.Both);
                             }
                         }
                     }


### PR DESCRIPTION
This PR fixes restored window size is bigger than expecting (ref: https://github.com/FancyWM/fancywm/issues/346).
`savedLocation.Parent.Attach` has already secured space, so `SizeTo` is appropriate in this situation.
I comfirm this change works rightly with building on my environment.
Thank @veselink1 for developping this great project for people on Windows hoping tiling window manager !