### PR TITLE
Fix ContainerWidth being zero case

### DIFF
--- a/FancyWM.Layouts/Flex.cs
+++ b/FancyWM.Layouts/Flex.cs
@@ -283,10 +283,16 @@ namespace FancyWM.Layouts
 
         private void ResizeContainer(double newWidth)
         {
-            double scaleFactor = newWidth / ContainerWidth;
+            Func<FlexConstraints, double> computeWidth = ContainerWidth.Eq(0)
+                ? _ => newWidth / m_items.Count
+                : x => x.Width * (newWidth / ContainerWidth);
+
             m_items = m_items
-                .Select(x => new FlexConstraints(Math.Clamp(x.Width * scaleFactor, x.MinWidth, x.MaxWidth), x.MinWidth, x.MaxWidth))
-                .ToList();
+                .Select(x => new FlexConstraints(
+                    Math.Clamp(computeWidth(x), x.MinWidth, x.MaxWidth),
+                        x.MinWidth,
+                        x.MaxWidth))
+                    .ToList();
             ContainerWidth = newWidth;
         }
 


### PR DESCRIPTION
With a `WindowPadding` of `0` and with a nested panel, the `ContainerWidth` can end up being 0, which causes scaleFactor to be infinity, and that contaminates all sorts of values to be NaN.

I think there might be better fixes architecturally, but I don't quite grasp how it all fits together, and this fixes things for me at least. 😇

Fixes #423 

