### PR TITLE
fix-autofocus-new-windows

### DIFF
--- a/FancyWM/TilingService.Private.cs
+++ b/FancyWM/TilingService.Private.cs
@@ -1045,6 +1045,28 @@ namespace FancyWM
                         }
 
                         InvalidateLayout();
+
+                        // Auto-focus the newly registered window
+                        // Use async pattern with delay to ensure Windows has fully initialized the window
+                        _ = m_dispatcher.BeginInvoke(async () =>
+                        {
+                            await Task.Delay(100);
+                            try
+                            {
+                                if (e.Source.IsAlive && (e.Source.State == WindowState.Restored || e.Source.State == WindowState.Maximized))
+                                {
+                                    FocusHelper.ForceActivate(e.Source.Handle);
+                                }
+                            }
+                            catch (InvalidWindowReferenceException)
+                            {
+                                // Window no longer exists, ignore
+                            }
+                            catch (Exception)
+                            {
+                                // Focus activation failed, ignore
+                            }
+                        }, System.Windows.Threading.DispatcherPriority.Background);
                     }, System.Windows.Threading.DispatcherPriority.DataBind);
                 }
             }


### PR DESCRIPTION
### What's Fixed
- Newly opened windows now automatically receive keyboard focus when registered with FancyWM
- This fixes issues where window launched via PowerToys hotkeys (or similar launchers) would open but not be active
-  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
### Technical Details
- Added `FocusHelper.ForceActivate()` call to `OnWindowAdded` method in `TilingService.Private.cs` 