### PR TITLE
[FEATURE] Add title-based ignore list for windows

### DIFF
--- a/FancyWM/Controls/TilingWindow.xaml
+++ b/FancyWM/Controls/TilingWindow.xaml
@@ -29,6 +29,14 @@
                     </StackPanel>
                 </MenuItem.Header>
             </MenuItem>
+            <MenuItem Command="{Binding IgnoreTitleCommand}">
+                <MenuItem.Header>
+                    <StackPanel Orientation="Horizontal">
+                        <ui:FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE82E;" FontSize="15" Margin="0, 0, 10, 0" />
+                        <TextBlock Text="{x:Static res:Strings.Overlay_Window_AddRuleForTitle}" />
+                    </StackPanel>
+                </MenuItem.Header>
+            </MenuItem>
         </ContextMenu>
     </UserControl.ContextMenu>
     <Grid>

--- a/FancyWM/MainWindow.xaml.cs
+++ b/FancyWM/MainWindow.xaml.cs
@@ -192,15 +192,17 @@ namespace FancyWM
                 .Select(_ => Unit.Default);
 
             var exclusionListSettings = settings
-                .DistinctUntilChanged(x => (x.ProcessIgnoreList, x.ClassIgnoreList))
+                .DistinctUntilChanged(x => (x.ProcessIgnoreList, x.ClassIgnoreList, x.TitleIgnoreList))
                 .Do(async x => await Dispatcher.InvokeAsync(() =>
                 {
                     var processMatchers = x.ProcessIgnoreList.Select(x => new ByProcessNameMatcher(x));
                     var classMatchers = x.ClassIgnoreList.Select(x => new ByClassNameMatcher(x));
+                    var titleMatchers = x.TitleIgnoreList.Select(x => new ByTitleMatcher(x));
                     m_tiling!.ExclusionMatchers = m_tiling.ExclusionMatchers
-                        .Where(m => m is not ByProcessNameMatcher && m is not ByClassNameMatcher)
+                        .Where(m => m is not ByProcessNameMatcher && m is not ByClassNameMatcher && m is not ByTitleMatcher)
                         .Concat(processMatchers)
                         .Concat(classMatchers)
+                        .Concat(titleMatchers)
                         .ToArray();
                 }))
                 .Select(_ => Unit.Default);

--- a/FancyWM/Models/Settings.cs
+++ b/FancyWM/Models/Settings.cs
@@ -87,6 +87,8 @@ namespace FancyWM.Models
             "RAIL_WINDOW",
         ];
 
+        public List<string> TitleIgnoreList { get; init; } = [];
+
         public bool RemindToRateReview { get; init; } = true;
 
         public bool ShowContextHints { get; init; } = true;

--- a/FancyWM/Pages/Settings/RulesPage.xaml
+++ b/FancyWM/Pages/Settings/RulesPage.xaml
@@ -33,6 +33,13 @@
                     <TextBlock HorizontalAlignment="Stretch" Padding="0,16,0,0" VerticalAlignment="Center" Foreground="{DynamicResource SystemControlPageTextBaseMediumBrush}" TextWrapping="Wrap" Text="{x:Static res:Strings.Rules_ClassIgnoreList_Description}" />
                 </StackPanel>
             </Border>
+            <Border Style="{DynamicResource SettingsItemStyle}">
+                <StackPanel Orientation="Vertical">
+                    <TextBlock VerticalAlignment="Center" Text="{x:Static res:Strings.Rules_TitleIgnoreList}" Margin="0, 0, 0, 16" />
+                    <controls:StringsListBox ItemsSource="{Binding TitleIgnoreList, Mode=TwoWay}" />
+                    <TextBlock HorizontalAlignment="Stretch" Padding="0,16,0,0" VerticalAlignment="Center" Foreground="{DynamicResource SystemControlPageTextBaseMediumBrush}" TextWrapping="Wrap" Text="{x:Static res:Strings.Rules_TitleIgnoreList_Description}" />
+                </StackPanel>
+            </Border>
         </ui:SimpleStackPanel>
     </Grid>
 </UserControl>

--- a/FancyWM/Resources/Strings.Designer.cs
+++ b/FancyWM/Resources/Strings.Designer.cs
@@ -2331,7 +2331,16 @@ namespace FancyWM.Resources {
                 return ResourceManager.GetString("Overlay.Window.AddRuleForProcess", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Add floating rule for window title.
+        /// </summary>
+        public static string Overlay_Window_AddRuleForTitle {
+            get {
+                return ResourceManager.GetString("Overlay.Window.AddRuleForTitle", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Drag over another window to group.
         /// </summary>
@@ -2439,7 +2448,25 @@ namespace FancyWM.Resources {
                 return ResourceManager.GetString("Rules.ProcessIgnoreList.Description", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Automatically float by window title.
+        /// </summary>
+        public static string Rules_TitleIgnoreList {
+            get {
+                return ResourceManager.GetString("Rules.TitleIgnoreList", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Floating mode will be automatically enabled for windows with a matching title. The matching is not case-sensitive and you may use regular expressions..
+        /// </summary>
+        public static string Rules_TitleIgnoreList_Description {
+            get {
+                return ResourceManager.GetString("Rules.TitleIgnoreList.Description", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Settings.
         /// </summary>

--- a/FancyWM/Resources/Strings.resx
+++ b/FancyWM/Resources/Strings.resx
@@ -540,6 +540,12 @@
   <data name="Rules.ProcessIgnoreList.Description" xml:space="preserve">
     <value>Floating mode will be automatically enabled for windows belonging to one of the processes. Enter one process name per line, excluding the ".exe" extension (e.g. "explorer"). The matching is not case-sensitive and you may use regular expressions.</value>
   </data>
+  <data name="Rules.TitleIgnoreList" xml:space="preserve">
+    <value>Automatically float by window title</value>
+  </data>
+  <data name="Rules.TitleIgnoreList.Description" xml:space="preserve">
+    <value>Floating mode will be automatically enabled for windows with a matching title. The matching is not case-sensitive and you may use regular expressions.</value>
+  </data>
   <data name="Settings" xml:space="preserve">
     <value>Settings</value>
   </data>
@@ -683,6 +689,9 @@
   </data>
   <data name="Overlay.Window.AddRuleForProcess" xml:space="preserve">
     <value>Add floating rule for process</value>
+  </data>
+  <data name="Overlay.Window.AddRuleForTitle" xml:space="preserve">
+    <value>Add floating rule for window title</value>
   </data>
   <data name="Overlay.Window.MoreOptions" xml:space="preserve">
     <value>More options</value>

--- a/FancyWM/TilingOverlayRenderer.cs
+++ b/FancyWM/TilingOverlayRenderer.cs
@@ -30,6 +30,7 @@ namespace FancyWM
         public event EventHandler<WindowNode>? FloatRequested;
         public event EventHandler<WindowNode>? IgnoreProcessRequested;
         public event EventHandler<WindowNode>? IgnoreClassRequested;
+        public event EventHandler<WindowNode>? IgnoreTitleRequested;
         public event EventHandler<WindowNode>? BeginHorizontalWithRequested;
         public event EventHandler<WindowNode>? BeginVerticalWithRequested;
         public event EventHandler<WindowNode>? BeginStackWithRequested;
@@ -249,6 +250,7 @@ namespace FancyWM
                     windowViewModel.StackActionPressed += WindowViewModel_StackActionPressed;
                     windowViewModel.IgnoreClassPressed += WindowViewModel_IgnoreClassPressed;
                     windowViewModel.IgnoreProcessPressed += WindowViewModel_IgnoreProcessPressed;
+                    windowViewModel.IgnoreTitlePressed += WindowViewModel_IgnoreTitlePressed;
                     UpdateViewModel(windowViewModel, windowNode, focusedPath);
                     m_nodeViewModels.Add(node, windowViewModel);
                     return windowViewModel;
@@ -315,6 +317,11 @@ namespace FancyWM
         private void WindowViewModel_IgnoreClassPressed(object sender, RoutedEventArgs e)
         {
             IgnoreClassRequested?.Invoke(this, ((WindowNode)((TilingWindowViewModel)sender!).Node!));
+        }
+
+        private void WindowViewModel_IgnoreTitlePressed(object sender, RoutedEventArgs e)
+        {
+            IgnoreTitleRequested?.Invoke(this, ((WindowNode)((TilingWindowViewModel)sender!).Node!));
         }
 
         private void OnSetPreviewWindows(IReadOnlySet<IWindow> oldValue, IReadOnlySet<IWindow> newValue)
@@ -515,6 +522,7 @@ namespace FancyWM
             FloatRequested = null;
             IgnoreProcessRequested = null;
             IgnoreClassRequested = null;
+            IgnoreTitleRequested = null;
         }
     }
 }

--- a/FancyWM/TilingService.Private.cs
+++ b/FancyWM/TilingService.Private.cs
@@ -831,6 +831,13 @@ namespace FancyWM
                 return x with { ClassIgnoreList = [.. x.ClassIgnoreList, ((WinMan.Windows.Win32Window)e.WindowReference).ClassName] };
             });
         }
+        private void OnWindowIgnoreTitleRequested(object? sender, WindowNode e)
+        {
+            App.Current.AppState.Settings.SaveAsync(x =>
+            {
+                return x with { TitleIgnoreList = [.. x.TitleIgnoreList, e.WindowReference.Title] };
+            });
+        }
 
         private void OnTilingPanelMoving(object? sender, PanelNode panel)
         {

--- a/FancyWM/TilingService.cs
+++ b/FancyWM/TilingService.cs
@@ -193,6 +193,7 @@ namespace FancyWM
             m_gui.StackRequested += OnWindowStackRequested;
             m_gui.IgnoreProcessRequested += OnWindowIgnoreProcessRequested;
             m_gui.IgnoreClassRequested += OnWindowIgnoreClassRequested;
+            m_gui.IgnoreTitleRequested += OnWindowIgnoreTitleRequested;
 
             AutoRegisterWindows = autoRegisterWindows;
 

--- a/FancyWM/Utilities/IWindowMatcher.cs
+++ b/FancyWM/Utilities/IWindowMatcher.cs
@@ -54,4 +54,14 @@ namespace FancyWM.Utilities
             return (window is WinMan.Windows.Win32Window w) && MatchHelpers.IsMatch(w.ClassName, ClassName);
         }
     }
+
+    internal class ByTitleMatcher(string titlePattern) : IWindowMatcher
+    {
+        public string TitlePattern { get; } = titlePattern;
+
+        public bool Matches(IWindow window)
+        {
+            return MatchHelpers.IsMatch(window.Title, TitlePattern);
+        }
+    }
 }

--- a/FancyWM/ViewModels/SettingsViewModel.cs
+++ b/FancyWM/ViewModels/SettingsViewModel.cs
@@ -190,6 +190,8 @@ namespace FancyWM.ViewModels
 
         public IList<string>? ClassIgnoreList { get => m_classIgnoreList; set => SetField(ref m_classIgnoreList, value); }
 
+        public IList<string>? TitleIgnoreList { get => m_titleIgnoreList; set => SetField(ref m_titleIgnoreList, value); }
+
         public bool MultiMonitorSupport { get => m_multiMonitorSupport; set => SetField(ref m_multiMonitorSupport, value); }
 
         public bool SoundOnFailure { get => m_soundOnFailure; set => SetField(ref m_soundOnFailure, value); }
@@ -218,6 +220,7 @@ namespace FancyWM.ViewModels
         private bool m_activateOnCapsLock;
         private IList<string>? m_processIgnoreList;
         private IList<string>? m_classIgnoreList;
+        private IList<string>? m_titleIgnoreList;
         private bool m_multiMonitorSupport;
         private bool m_showContextHints;
         private bool m_soundOnFailure;
@@ -255,6 +258,7 @@ namespace FancyWM.ViewModels
                     PanelFontSize = settings.PanelFontSize;
                     ProcessIgnoreList = settings.ProcessIgnoreList;
                     ClassIgnoreList = settings.ClassIgnoreList;
+                    TitleIgnoreList = settings.TitleIgnoreList;
                     MultiMonitorSupport = settings.MultiMonitorSupport;
                     ShowContextHints = settings.ShowContextHints;
                     SoundOnFailure = settings.SoundOnFailure;
@@ -382,6 +386,7 @@ namespace FancyWM.ViewModels
                     ShowContextHints = ShowContextHints,
                     ProcessIgnoreList = [.. ProcessIgnoreList!],
                     ClassIgnoreList = [.. ClassIgnoreList!],
+                    TitleIgnoreList = [.. TitleIgnoreList!],
                     MultiMonitorSupport = MultiMonitorSupport,
                     SoundOnFailure = SoundOnFailure,
                     ShowFocus = ShowFocus,

--- a/FancyWM/ViewModels/TilingWindowViewModel.cs
+++ b/FancyWM/ViewModels/TilingWindowViewModel.cs
@@ -59,6 +59,7 @@ namespace FancyWM.ViewModels
         public event RoutedEventHandler? FloatActionPressed;
         public event RoutedEventHandler? IgnoreProcessPressed;
         public event RoutedEventHandler? IgnoreClassPressed;
+        public event RoutedEventHandler? IgnoreTitlePressed;
 
         public ICommand BeginHorizontalSplitWithCommand { get; }
         public ICommand BeginVerticalSplitWithCommand { get; }
@@ -67,6 +68,7 @@ namespace FancyWM.ViewModels
         public ICommand FloatCommand { get; }
         public ICommand IgnoreProcessCommand { get; }
         public ICommand IgnoreClassCommand { get; }
+        public ICommand IgnoreTitleCommand { get; }
 
         public TilingWindowViewModel()
         {
@@ -77,6 +79,7 @@ namespace FancyWM.ViewModels
             FloatCommand = new DelegateCommand(_ => FloatActionPressed?.Invoke(this, new RoutedEventArgs()));
             IgnoreProcessCommand = new DelegateCommand(_ => IgnoreProcessPressed?.Invoke(this, new RoutedEventArgs()));
             IgnoreClassCommand = new DelegateCommand(_ => IgnoreClassPressed?.Invoke(this, new RoutedEventArgs()));
+            IgnoreTitleCommand = new DelegateCommand(_ => IgnoreTitlePressed?.Invoke(this, new RoutedEventArgs()));
         }
 
         public override void Dispose()
@@ -85,6 +88,7 @@ namespace FancyWM.ViewModels
             FloatActionPressed = null;
             IgnoreProcessPressed = null;
             IgnoreClassPressed = null;
+            IgnoreTitlePressed = null;
             Node = null;
         }
 


### PR DESCRIPTION
Float windows automatically based on the window title, similar to the functionality provided by the class and process ignore lists.

This feature is something I would like to make my current setup work: Godot and my external editor tiled, but the game debug window floating. I can't use the existing functionality since both windows have the same process and class. This was already requested in #200, but it seems it did not get any response. There is also another similar issue #83, but this PR might not fully solve that use-case.

I implemented the feature by extending the IWindowMatcher framework with ByTitleMatcher class and TitleIgnoreList property, following the pattern used for the already existing exclusion types.
